### PR TITLE
engine: add `info` endpoint parsing

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -19,6 +19,77 @@ pub struct Version {
     pub build_time: String,
 }
 
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct Plugins {
+    pub volume: Option<Vec<String>>,
+    pub network: Option<Vec<String>>,
+    pub log: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct RegistryConfig {
+    // TODO: add proper parameters for "IndexConfigs"
+    // pub index_configs:
+    #[serde(rename(deserialize = " InsecureRegistryCIDRs"))]
+    pub insecure_registry_cidrs: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct Info {
+    pub architecture: Option<String>,
+    pub containers: Option<u64>,
+    pub containers_running: Option<u64>,
+    pub containers_stopped: Option<u64>,
+    pub containers_paused: Option<u64>,
+    pub cpu_cfs_period: Option<bool>,
+    pub cpu_cfs_quota: Option<bool>,
+    pub debug: Option<bool>,
+    pub discovery_backend: Option<String>,
+    pub docker_root_dir: Option<String>,
+    pub driver: Option<String>,
+    pub driver_status: Option<Vec<Vec<String>>>,
+    pub system_status: Option<Vec<Vec<String>>>,
+    pub plugins: Option<Plugins>,
+    pub experimental_build: Option<bool>,
+    pub http_proxy: Option<String>,
+    pub https_proxy: Option<String>,
+    #[serde(rename(deserialize = "ID"))]
+    pub id: Option<String>,
+    #[serde(rename(deserialize = "ID"))]
+    pub ipv4_forwarding: Option<bool>,
+    pub images: Option<u64>,
+    pub index_server_address: Option<String>,
+    pub init_path: Option<String>,
+    pub init_sha1: Option<String>,
+    pub kernel_version: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub mem_total: Option<u64>,
+    pub memory_limit: Option<bool>,
+    #[serde(rename(deserialize = "NCPU"))]
+    pub ncpu: Option<u64>,
+    pub n_events_listener: Option<u64>,
+    pub n_fd: Option<u64>,
+    pub n_goroutines: Option<u64>,
+    pub name: Option<String>,
+    pub no_proxy: Option<String>,
+    pub oom_kill_disable: Option<bool>,
+    #[serde(rename(deserialize = "OSType"))]
+    pub os_type: Option<String>,
+    pub oom_score_adj: Option<i64>,
+    pub operating_system: Option<String>,
+    pub registry_config: Option<RegistryConfig>,
+    pub swap_limit: Option<bool>,
+    pub system_time: Option<String>,
+    pub server_version: Option<String>,
+}
+
+pub fn version_parse(json: &str) -> Result<Version> {
+    serde_json::from_str(json).chain_err(|| "Failed to deserialize version response")
+}
+
 pub fn version(client: Client) -> Result<Version> {
     let response = get(client, "/version").chain_err(|| "Failed to get engine version")?;
 
@@ -26,10 +97,21 @@ pub fn version(client: Client) -> Result<Version> {
         bail!("non-200 response from server");
     }
 
-    let version: Version =
-        serde_json::from_str(&response.body).chain_err(|| "Failed to deserialize engine response")?;
+    version_parse(&response.body)
+}
 
-    Ok(version)
+pub fn info_parse(json: &str) -> Result<Info> {
+    serde_json::from_str(json).chain_err(|| "Failed to deserialize info response")
+}
+
+pub fn info(client: Client) -> Result<Info> {
+    let response = get(client, "/info").chain_err(|| "Failed to get engine version")?;
+
+    if response.status_code != 200 {
+        bail!("non-200 response from server");
+    }
+
+    info_parse(&response.body)
 }
 
 pub fn ping(client: Client) -> Result<()> {

--- a/tests/fixtures/info_docs.json
+++ b/tests/fixtures/info_docs.json
@@ -1,0 +1,97 @@
+{
+  "Architecture": "x86_64",
+  "ClusterStore": "etcd://localhost:2379",
+  "CgroupDriver": "cgroupfs",
+  "Containers": 11,
+  "ContainersRunning": 7,
+  "ContainersStopped": 3,
+  "ContainersPaused": 1,
+  "CpuCfsPeriod": true,
+  "CpuCfsQuota": true,
+  "Debug": false,
+  "DockerRootDir": "/var/lib/docker",
+  "Driver": "btrfs",
+  "DriverStatus": [
+    [
+      ""
+    ]
+  ],
+  "ExperimentalBuild": false,
+  "HttpProxy": "http://test:test@localhost:8080",
+  "HttpsProxy": "https://test:test@localhost:8080",
+  "ID": "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
+  "IPv4Forwarding": true,
+  "Images": 16,
+  "IndexServerAddress": "https://index.docker.io/v1/",
+  "InitPath": "/usr/bin/docker",
+  "InitSha1": "",
+  "KernelMemory": true,
+  "KernelVersion": "3.12.0-1-amd64",
+  "Labels": [
+    "storage=ssd"
+  ],
+  "MemTotal": 2099236864,
+  "MemoryLimit": true,
+  "NCPU": 1,
+  "NEventsListener": 0,
+  "NFd": 11,
+  "NGoroutines": 21,
+  "Name": "prod-server-42",
+  "NoProxy": "9.81.1.160",
+  "OomKillDisable": true,
+  "OSType": "linux",
+  "OperatingSystem": "Boot2Docker",
+  "Plugins": {
+    "Volume": [
+      "local"
+    ],
+    "Network": [
+      "null",
+      "host",
+      "bridge"
+    ]
+  },
+  "RegistryConfig": {
+    "IndexConfigs": {
+      "docker.io": {
+        "Name": "docker.io",
+        "Official": true,
+        "Secure": true
+      }
+    },
+    "InsecureRegistryCIDRs": [
+      "127.0.0.0/8"
+    ]
+  },
+  "SecurityOptions": [
+    {
+      "Key": "Name",
+      "Value": "seccomp"
+    },
+    {
+      "Key": "Profile",
+      "Value": "default"
+    },
+    {
+      "Key": "Name",
+      "Value": "apparmor"
+    },
+    {
+      "Key": "Name",
+      "Value": "selinux"
+    },
+    {
+      "Key": "Name",
+      "Value": "userns"
+    }
+  ],
+  "ServerVersion": "1.9.0",
+  "SwapLimit": false,
+  "SystemStatus": [
+    [
+      "State",
+      "Healthy"
+    ]
+  ],
+  "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
+}

--- a/tests/fixtures/info_real.json
+++ b/tests/fixtures/info_real.json
@@ -1,0 +1,132 @@
+{
+  "ID": "4MOQ:FEIJ:DLRQ:D2V6:ZZCK:SZFD:WDGW:EOCV:CXSB:A3J6:EUFV:AJEL",
+  "Containers": 0,
+  "ContainersRunning": 0,
+  "ContainersPaused": 0,
+  "ContainersStopped": 0,
+  "Images": 2,
+  "Driver": "overlay2",
+  "DriverStatus": [
+    [
+      "Backing Filesystem",
+      "extfs"
+    ],
+    [
+      "Supports d_type",
+      "true"
+    ],
+    [
+      "Native Overlay Diff",
+      "false"
+    ]
+  ],
+  "SystemStatus": null,
+  "Plugins": {
+    "Volume": [
+      "local"
+    ],
+    "Network": [
+      "bridge",
+      "host",
+      "macvlan",
+      "null",
+      "overlay"
+    ],
+    "Authorization": null,
+    "Log": [
+      "awslogs",
+      "fluentd",
+      "gcplogs",
+      "gelf",
+      "journald",
+      "json-file",
+      "logentries",
+      "splunk",
+      "syslog"
+    ]
+  },
+  "MemoryLimit": true,
+  "SwapLimit": true,
+  "KernelMemory": true,
+  "CpuCfsPeriod": true,
+  "CpuCfsQuota": true,
+  "CPUShares": true,
+  "CPUSet": true,
+  "IPv4Forwarding": true,
+  "BridgeNfIptables": true,
+  "BridgeNfIp6tables": true,
+  "Debug": false,
+  "NFd": 19,
+  "OomKillDisable": true,
+  "NGoroutines": 32,
+  "SystemTime": "2018-04-09T23:05:15.8246835+01:00",
+  "LoggingDriver": "json-file",
+  "CgroupDriver": "cgroupfs",
+  "NEventsListener": 0,
+  "KernelVersion": "4.15.15-1-ARCH",
+  "OperatingSystem": "Arch Linux",
+  "OSType": "linux",
+  "Architecture": "x86_64",
+  "IndexServerAddress": "https://index.docker.io/v1/",
+  "RegistryConfig": {
+    "AllowNondistributableArtifactsCIDRs": [],
+    "AllowNondistributableArtifactsHostnames": [],
+    "InsecureRegistryCIDRs": [
+      "127.0.0.0/8"
+    ],
+    "IndexConfigs": {
+      "docker.io": {
+        "Name": "docker.io",
+        "Mirrors": [],
+        "Secure": true,
+        "Official": true
+      }
+    },
+    "Mirrors": []
+  },
+  "NCPU": 4,
+  "MemTotal": 20767236096,
+  "GenericResources": null,
+  "DockerRootDir": "/var/lib/docker",
+  "HttpProxy": "",
+  "HttpsProxy": "",
+  "NoProxy": "",
+  "Name": "hydra",
+  "Labels": [],
+  "ExperimentalBuild": false,
+  "ServerVersion": "18.03.0-ce",
+  "ClusterStore": "",
+  "ClusterAdvertise": "",
+  "Runtimes": {
+    "runc": {
+      "path": "docker-runc"
+    }
+  },
+  "DefaultRuntime": "runc",
+  "Swarm": {
+    "NodeID": "",
+    "NodeAddr": "",
+    "LocalNodeState": "inactive",
+    "ControlAvailable": false,
+    "Error": "",
+    "RemoteManagers": null
+  },
+  "LiveRestoreEnabled": false,
+  "Isolation": "",
+  "InitBinary": "docker-init",
+  "ContainerdCommit": {
+    "ID": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c",
+    "Expected": "cfd04396dc68220d1cecbe686a6cc3aa5ce3667c"
+  },
+  "RuncCommit": {
+    "ID": "4fc53a81fb7c994640722ac585fa9ca548971871",
+    "Expected": "4fc53a81fb7c994640722ac585fa9ca548971871"
+  },
+  "InitCommit": {
+    "ID": "949e6fa",
+    "Expected": "949e6fa"
+  },
+  "SecurityOptions": [
+    "name=seccomp,profile=default"
+  ]
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -61,7 +61,7 @@ mod tests {
     mod engine {
 
         use narwhal::engine;
-        use super::get_client;
+        use super::{get_client, read_fixture};
 
         #[test]
         pub fn get_version() {
@@ -72,6 +72,46 @@ mod tests {
                 use error_chain::ChainedError;
                 print!("{}", e.display_chain());
                 assert!(false, "Could not get engine version");
+            }
+        }
+
+        #[test]
+        pub fn parse_info_docs() {
+            let test_str = read_fixture("info_docs");
+            let parsed = engine::info_parse(&test_str).expect("Error parsing info fixture");
+
+            assert_eq!(parsed.architecture.unwrap(), "x86_64");
+            assert_eq!(parsed.discovery_backend.is_none(), true);
+            assert_eq!(parsed.debug.unwrap(), false);
+            assert_eq!(parsed.images.unwrap(), 16);
+            assert_eq!(parsed.labels.unwrap().len(), 1);
+            assert_eq!(parsed.plugins.unwrap().network.unwrap().len(), 3);
+            assert_eq!(parsed.system_status.unwrap()[0][1], "Healthy");
+        }
+
+        #[test]
+        pub fn parse_info() {
+            let test_str = read_fixture("info_real");
+            let parsed = engine::info_parse(&test_str).expect("Error parsing info fixture");
+
+            assert_eq!(
+                parsed.index_server_address.unwrap(),
+                "https://index.docker.io/v1/"
+            );
+            assert_eq!(parsed.labels.unwrap().len(), 0);
+            assert_eq!(parsed.system_status.is_none(), true);
+            assert_eq!(parsed.server_version.unwrap(), "18.03.0-ce");
+        }
+
+        #[test]
+        pub fn get_info() {
+            let c = get_client();
+            let info = engine::info(c);
+
+            if let Err(ref e) = info {
+                use error_chain::ChainedError;
+                print!("{}", e.display_chain());
+                assert!(false, "Could not get engine info");
             }
         }
 


### PR DESCRIPTION
Most of it, at least, outstanding items marked as TODO (that's mainly the "RegistryConfig" entry which is unclear how it should look, really, as of now.

Change-type: patch